### PR TITLE
Update Eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,9 @@
       "strict": 0,
       "no-console": 0,
       "prefer-const": 0,
-      "comma-dangle": 0
+      "comma-dangle": 0,
+      "react/prefer-es6-class": [1, "never"],
+      "react/react-in-jsx-scope": 1
   },
   "env": {
       "es6": true,


### PR DESCRIPTION
This adds the below eslintrc react rules:
- [react-in-jsx-scope](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md): warns you when you use JSX and React is not in scope ( i.e. when creating a functional component )
- [prefer-es6-class](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md): I've set the rule so that it will prefer React.createClass and give a warning when you try to use es6 classes for a React component.
