### PR TITLE
(chore) collapse action logs by default

### DIFF
--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -6,7 +6,7 @@ import { connection, r } from '../utils/rethink';
 import { addMessage, fetchMessages } from '../actions';
 
 export default function configureStore(initialState) {
-  const logger = createLogger();
+  const logger = createLogger({collapsed: true});
   const store = createStore(
     rootReducer,
     applyMiddleware(thunk, logger)


### PR DESCRIPTION
I often test/debug things with console.log, and 4 lines in my console for every 1 action adds unnecessary clutter. This PR makes the logs printed in the console for each action collapsed by default they don't overwhelm/obscure other logs.

Thought it might help; if not, that's fine. :)
