### PR TITLE
(feat) add global notifications system

### DIFF
--- a/__tests__/notificationsReducer-test.js
+++ b/__tests__/notificationsReducer-test.js
@@ -1,0 +1,70 @@
+/* global describe, it, expect, jest, beforeEach */
+
+jest.unmock('../app/actions');
+jest.unmock('../app/actions/notificationsActions');
+jest.unmock('../app/actions/averagesActions');
+jest.unmock('../app/reducers/notificationsReducer');
+jest.unmock('redux');
+
+import { addNotification, nextNotification } from '../app/actions';
+import notifications from '../app/reducers/notificationsReducer';
+
+describe('notifications', () => {
+  it('should have the correct default state', () => {
+    const initialState = {
+      currentNotification: false,
+      queue: [],
+    };
+
+    expect(notifications(undefined, {})).toEqual(initialState);
+  });
+
+  describe('ADD_NOTIFICATION', () => {
+    it('should add a notification to the queue', () => {
+      const initialState = {
+        currentNotification: false,
+        queue: [],
+      };
+      const expectedState = {
+        currentNotification: false,
+        queue: [
+          { message: 'Hello world!', style: 'error' }
+        ],
+      };
+
+      expect(
+        notifications(initialState, addNotification('Hello world!', 'error'))
+      ).toEqual(expectedState);
+    });
+  });
+
+  describe('NEXT_NOTIFICATION', () => {
+    it('it should remove a notification from the queue and make it the current notification', () => {
+      const initialState = {
+        currentNotification: false,
+        queue: [
+          { message: 'Hello world!', style: 'error' }
+        ],
+      };
+      const expectedState = {
+        currentNotification: { message: 'Hello world!', style: 'error' },
+        queue: [],
+      };
+
+      expect(notifications(initialState, nextNotification())).toEqual(expectedState);
+    });
+
+    it('should remove the currentNotification if the queue is empty', () => {
+      const initialState = {
+        currentNotification: { message: 'Hello world!', style: 'error' },
+        queue: [],
+      };
+      const expectedState = {
+        currentNotification: false,
+        queue: [],
+      };
+
+      expect(notifications(initialState, nextNotification())).toEqual(expectedState);
+    });
+  });
+});

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,5 +1,7 @@
 import * as queries from './queries';
 
+export * from './notificationsActions';
+
 export const ADD_MESSAGE = 'ADD_MESSAGE';
 export const addMessage = message => ({ type: ADD_MESSAGE, message });
 

--- a/app/actions/notificationsActions.js
+++ b/app/actions/notificationsActions.js
@@ -1,0 +1,27 @@
+// Duration in seconds that a notification will last
+const DURATION = 3;
+
+export const ADD_NOTIFICATION = 'ADD_NOTIFICATION';
+export const addNotification = (message, style) => (
+  { type: ADD_NOTIFICATION, notification: { message, style } }
+);
+
+export const NEXT_NOTIFICATION = 'NEXT_NOTIFICATION';
+export const nextNotification = () => ({ type: NEXT_NOTIFICATION });
+
+const tick = () => (dispatch, getState) => {
+  dispatch(nextNotification());
+  window.setTimeout(() => {
+    if (getState().notifications.currentNotification) {
+      dispatch(tick());
+    }
+  }, DURATION * 1000);
+};
+
+export const notify = (message, style) => (dispatch, getState) => {
+  dispatch(addNotification(message, style));
+  if (!getState().notifications.currentNotification) {
+    dispatch(tick());
+  }
+};
+

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,14 +1,23 @@
 import React from 'react';
-import { Link } from 'react-router';
+import GlobalNotifications from '../containers/GlobalNotifications';
 
 const Main = React.createClass({
-  render: function () {
+  render() {
+    const NotificationsStyleMap = {
+      error: 'is-danger',
+      warning: 'is-warning',
+      info: 'is-info',
+      success: 'is-success',
+      primary: 'is-primary'
+    };
+
     return (
-        <div>
-          {this.props.children}
-        </div>
-      )
+      <div>
+        <GlobalNotifications styleMap={NotificationsStyleMap} />
+        {this.props.children}
+      </div>
+    );
   }
-})
+});
 
 export default Main;

--- a/app/containers/GlobalNotifications.js
+++ b/app/containers/GlobalNotifications.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+// Note: This could be a pure functional component...
+// I'm not sure whether it will need any lifecycle methods if/when
+// we decide to improve it, so I'm not sure I should move it over to a functional
+// component yet
+const GlobalNotifications = React.createClass({
+  propTypes: {
+    styleMap: React.PropTypes.object.isRequired,
+    notifications: React.PropTypes.object,
+  },
+
+  render() {
+    const { notifications: { currentNotification }, styleMap } = this.props;
+    return (
+      <div style={{ position: 'fixed', width: '50%', left: '50%', zIndex: '9999' }}>
+        { currentNotification && (
+          <div className={`notification ${styleMap[currentNotification.style] || styleMap.info}`}>
+            <button className="delete"></button>
+              {currentNotification.message}
+          </div>
+        )}
+      </div>
+    );
+  }
+});
+
+function mapStateToProps(state) {
+  return {
+    notifications: state.notifications
+  };
+}
+
+export default connect(mapStateToProps)(GlobalNotifications);

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import messages from './messages';
 import SearchBoxReducer from './SearchBoxReducer';
 import averages from './averagesReducer';
+import notifications from './notificationsReducer';
 
 const rootReducer = combineReducers({
   messages,
   SearchBoxReducer,
-  averages
+  averages,
+  notifications
 });
 
 export default rootReducer;

--- a/app/reducers/notificationsReducer.js
+++ b/app/reducers/notificationsReducer.js
@@ -1,0 +1,24 @@
+import { ADD_NOTIFICATION, NEXT_NOTIFICATION } from '../actions';
+
+const initialState = {
+  currentNotification: false,
+  queue: []
+};
+
+export default function notificationsReducer(state = initialState, action) {
+  switch (action.type) {
+    case ADD_NOTIFICATION:
+      return {
+        ...state,
+        queue: [...state.queue, action.notification]
+      };
+    case NEXT_NOTIFICATION:
+      return {
+        ...state,
+        currentNotification: state.queue[0] || false,
+        queue: state.queue.slice(0, state.queue.length - 1)
+      };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
This PR adds a global notifications system that will spawn a notification with your desired style and message for 3 seconds.

You can use it by dispatching a `notify` action, passing in the message and the type of style.
ex: 

``` js
import { notify } from 'app/actions';
dispatch(notify('This is my message text', 'error'))
```

Available style options: 
- error
- warning
- info
- success
- primary
