### PR TITLE
(feat) Fix navbar for questions page to show relevant information

### DIFF
--- a/app/components/Messages.js
+++ b/app/components/Messages.js
@@ -22,8 +22,8 @@ const Messages = ({ messages, filterUserMessages }) => {
                 </div>
 
                 <div className="media-content">
-                  <p className="title is-5">{message.name}</p>
-                  <p className="subtitle is-6">{message.profile.real_name? message.profile.real_name : message.profile.email}</p>
+                  <p className="title is-5" style={styles.userInfo}>{message.name}</p>
+                  <p className="subtitle is-6" style={styles.userInfo}>{message.profile.real_name? message.profile.real_name : message.profile.email}</p>
                 </div>
               </div>
 

--- a/app/components/Messages.js
+++ b/app/components/Messages.js
@@ -11,7 +11,7 @@ const Messages = ({ messages, filterUserMessages }) => {
       {sorted.map(message => {
         let time = moment(new Date(message.ts));
         return (
-          <div className="card">
+          <div className="card" style={styles.cards}>
             <div className="card-content">
 
               <div className="media">

--- a/app/components/QuestionMessages.js
+++ b/app/components/QuestionMessages.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import moment from 'moment';
+import styles from '../styles';
+import { Link } from 'react-router';
+
+const QuestionMessages = ({ messages, filterUserMessages }) => {
+  const comparator = (a, b) => { return new Date(b.ts) - new Date(a.ts) };
+  const sorted = messages.sort(comparator);
+  return (
+    <div style={styles.ofprot}>
+      {sorted.map(message => {
+        let time = moment(new Date(message.ts));
+        return (
+          <div className="card">
+            <div className="card-content">
+
+              <div className="media">
+                <div className="media-left">
+                  <figure className="image is-32x32">
+                    <img src={message.profile.image_24} />
+                  </figure>
+                </div>
+
+                <div className="media-content">
+                  <p className="title is-5">{message.name}</p>
+                  <p className="subtitle is-6">{message.profile.real_name? message.profile.real_name : message.profile.email}</p>
+                </div>
+              </div>
+
+              <div className="content">
+                {message.text}
+                <br></br>
+                <small>
+                  <Link to={`/user/${message.user}`}> Details </Link>
+                </small>
+                <br/>
+                <small>{time.fromNow()}</small>
+              </div>
+
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  );
+};
+
+export default QuestionMessages;

--- a/app/components/QuestionMessages.js
+++ b/app/components/QuestionMessages.js
@@ -11,7 +11,7 @@ const QuestionMessages = ({ messages, filterUserMessages }) => {
       {sorted.map(message => {
         let time = moment(new Date(message.ts));
         return (
-          <div className="card">
+          <div className="card" style={styles.cards}>
             <div className="card-content">
 
               <div className="media">

--- a/app/components/QuestionMessages.js
+++ b/app/components/QuestionMessages.js
@@ -20,10 +20,9 @@ const QuestionMessages = ({ messages, filterUserMessages }) => {
                     <img src={message.profile.image_24} />
                   </figure>
                 </div>
-
                 <div className="media-content">
-                  <p className="title is-5">{message.name}</p>
-                  <p className="subtitle is-6">{message.profile.real_name? message.profile.real_name : message.profile.email}</p>
+                  <p className="title is-5" style={styles.userInfo}>{message.name}</p>
+                  <p className="subtitle is-6" style={styles.userInfo}>{message.profile.real_name? message.profile.real_name : message.profile.email}</p>
                 </div>
               </div>
 

--- a/app/components/QuestionNavbar.js
+++ b/app/components/QuestionNavbar.js
@@ -1,0 +1,28 @@
+/* eslint-disable */
+import React from 'react';
+
+const QuestionNavbar = ({ messages, analytics, users }) => {
+  //console.log(JSON.stringify(analytics));
+  return (
+    <nav className="navbar">
+     <div className="navbar-item is-text-centered">
+      <p className="title">{messages.length}</p>
+      <p className="heading">Total Questions</p>
+    </div>
+     <div className="navbar-item is-text-centered">
+      <p className="title">{ (analytics.totalSentiment / messages.length).toFixed(1) }</p>
+      <p className="heading">Average Sentiment</p>
+    </div>
+     <div className="navbar-item is-text-centered">
+      <p className="title">{ users.join(', ')}</p>
+      <p className="heading">{ users.length <= 1 ? 'is' : 'are'} Active</p>
+    </div>
+    <div className="navbar-item is-text-centered">
+      <p className="title">{analytics.topics.join(', ') || 'N/A'}</p>
+      <p className="heading">{analytics.topics.length <= 1 ? 'is' : 'are'} Trending</p>
+    </div>
+    </nav>
+    )
+}
+
+export default QuestionNavbar;

--- a/app/components/Questions.js
+++ b/app/components/Questions.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactRouter from 'react-router';
-import MessagesContainer from '../containers/MessagesContainer';
 import QuestionsContainer from '../containers/QuestionsContainer'
 import NavbarContainer from '../containers/NavbarContainer';
 import QuestionNavbarContainer from '../containers/QuestionNavbarContainer';
 import LeftPanelContainer from '../containers/LeftPanelContainer';
 import SearchBoxContainer from '../containers/SearchBoxContainer';
+import QuestionMessageContainer from '../containers/QuestionMessageContainer';
 
 const Questions = React.createClass({
   render: function () {
@@ -23,7 +23,7 @@ const Questions = React.createClass({
             <QuestionsContainer />
           </div>
           <div className="column is-quarter">
-            <MessagesContainer />
+            <QuestionMessageContainer />
           </div>
           </div>
       </div>

--- a/app/components/Questions.js
+++ b/app/components/Questions.js
@@ -3,6 +3,7 @@ import ReactRouter from 'react-router';
 import MessagesContainer from '../containers/MessagesContainer';
 import QuestionsContainer from '../containers/QuestionsContainer'
 import NavbarContainer from '../containers/NavbarContainer';
+import QuestionNavbarContainer from '../containers/QuestionNavbarContainer';
 import LeftPanelContainer from '../containers/LeftPanelContainer';
 import SearchBoxContainer from '../containers/SearchBoxContainer';
 
@@ -10,7 +11,7 @@ const Questions = React.createClass({
   render: function () {
     return (
       <div className="container is-fluid">
-        <NavbarContainer/>
+        <QuestionNavbarContainer/>
         <h1 className="control">
           <SearchBoxContainer />
         </h1>

--- a/app/components/WordCountBarGraph.js
+++ b/app/components/WordCountBarGraph.js
@@ -19,9 +19,13 @@ let WordCountBarGraph = ({data = [], labels = []}) => {
     };
 
   const barChartOptions = {
-
-  //Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
-  scaleBeginAtZero : true,
+    scales:{
+      yAxes:[{
+        ticks:{
+          beginAtZero:true
+        }
+      }]
+    },
 
   //Boolean - Whether grid lines are shown across the chart
   scaleShowGridLines : true,

--- a/app/containers/QuestionMessageContainer.js
+++ b/app/containers/QuestionMessageContainer.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import QuestionMessages from '../components/QuestionMessages';
+import { filterMessages } from '../actions/index';
+
+const mapStateToProps = (state) => {
+  return {
+    messages: state.messages.messages.filter(messages => messages.classification !== undefined)
+  }
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    filterUserMessages(username){
+      dispatch(filterMessages(username))
+    }
+  }
+}
+
+// const GetMessages = connect(mapStateToProps)(Messages);
+
+export default connect(mapStateToProps, mapDispatchToProps)(QuestionMessages);

--- a/app/containers/QuestionNavbarContainer.js
+++ b/app/containers/QuestionNavbarContainer.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+import React from 'react';
+import QuestionNavbar from '../components/QuestionNavbar';
+import _ from 'lodash';
+
+const getAnalytics = (messages) => {
+  let analytics = messages.reduce((acc, message) => {
+    acc.totalSentiment += message.score;
+    return acc;
+  }, { totalSentiment: 0 });
+
+  return analytics;
+};
+
+let mapStateToProps = (state) => {
+  return {
+    messages: state.messages.messages.filter(message => message['classification'] !== undefined),
+    analytics: Object.assign({}, getAnalytics(state.messages.messages),
+    {
+      topics: state.classify.classify.classifications
+        .map(classification => [classification.group, classification.reduction])
+        .sort((a,b) => b[1] - a[1]).splice(0,3)
+        .map(topic => topic[0])
+    }),
+    users: state.engagement.slice().map(user => user.name).slice(0,3)
+  }
+};
+
+
+export default connect(mapStateToProps)(QuestionNavbar);

--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -25,6 +25,9 @@ var styles = {
     margin: '8px',
     'border-radius': '2px',
     width: 'auto'
+  },
+  userInfo:{
+    'word-wrap': 'break-word'
   }
 };
 

--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -20,6 +20,11 @@ var styles = {
   ofprot: {
     height: '750px',
     overflow: 'scroll'
+  },
+  cards:{
+    margin: '8px',
+    'border-radius': '2px',
+    width: 'auto'
   }
 };
 

--- a/server/bot/listeners/question.js
+++ b/server/bot/listeners/question.js
@@ -92,10 +92,16 @@ export default (controller) => {
                         default: true,
                         callback: (res, convo) => {
                           convo.next();
-                          // saveMsg(message, res.text);
-                          convo.say('Recorded your question about ' + res.text + ', thanks for making me smarter!');
-                          classifier.addDocument(message.text, res.text);
-                          classifier.train();
+                          //check to make sure user entered a valid category
+                          if(res.text === topThree[0] || res.text === topThree[1] || res.text === topThree[2]){
+
+                            saveMsg(message, res.text);
+                            convo.say('Recorded your question about ' + res.text + ', thanks for making me smarter!');
+                            classifier.addDocument(message.text, res.text);
+                            classifier.train();
+                          } else{
+                            convo.say('Sorry, that wasn\'t one of the categories listed, I\'ll try again next time.');
+                          }
                           convo.next();
                         }
                       }


### PR DESCRIPTION
Sorry, this commit should have been broken up, but here's a quick summary of what I did:

1.Make the information at the top of the /questions page relevant to the information on the page
2.Only show question cards on the /question page instead of all messages
3.Fixed bot logic so now questions are stored when the user first responds with 'no'
4.Made the word count graph start at 0 instead of the lowest value, otherwise the lowest looked empty
5.Changed the styling on the cards so they fill the div and added a small border-radius so they aren't as sharp and aren't stacked right on each other.
6. Fixed issue with card info overflowing
